### PR TITLE
chore: migrate remaining Coveralls references to Codecov

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 <p align=center>
   <a href="https://github.com/contributte/jsonrpc/actions"><img src="https://badgen.net/github/checks/contributte/jsonrpc/master"></a>
-  <a href="https://coveralls.io/r/contributte/jsonrpc"><img src="https://badgen.net/coveralls/c/github/contributte/jsonrpc"></a>
+  <a href="https://codecov.io/gh/contributte/jsonrpc"><img src="https://badgen.net/codecov/c/github/contributte/jsonrpc"></a>
   <a href="https://packagist.org/packages/contributte/jsonrpc"><img src="https://badgen.net/packagist/dm/contributte/jsonrpc"></a>
   <a href="https://packagist.org/packages/contributte/jsonrpc"><img src="https://badgen.net/packagist/v/contributte/jsonrpc"></a>
 </p>


### PR DESCRIPTION
## What changed
- replaced the README coverage badge link and image from Coveralls to Codecov
- confirmed the repository already uses the reusable Codecov coverage workflow and does not contain `tests/.coveralls.yml`

## Why
- continues the Coveralls-to-Codecov migration tracked in contributte/contributte#72