### PR TITLE
Remove phpdbg from coverage target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,7 +28,7 @@ tests:
 .PHONY: coverage
 coverage:
 ifdef GITHUB_ACTION
-	vendor/bin/tester -s -p phpdbg --colors 1 -C --coverage coverage.xml --coverage-src src tests/Cases
+	vendor/bin/tester -s -p php --colors 1 -C --coverage coverage.xml --coverage-src src tests/Cases
 else
-	vendor/bin/tester -s -p phpdbg --colors 1 -C --coverage coverage.html --coverage-src src tests/Cases
+	vendor/bin/tester -s -p php --colors 1 -C --coverage coverage.html --coverage-src src tests/Cases
 endif


### PR DESCRIPTION
## Summary

Replace `phpdbg` with plain `php` in the `coverage` target so this repository matches the org-wide coverage runner migration tracked in contributte/contributte#73.

## Motivation

`phpdbg` is being removed from Contributte coverage targets. This keeps `contributte/jsonrpc` aligned with that change.

## Changes

- switch the GitHub Actions coverage command in `Makefile` from `-p phpdbg` to `-p php`
- switch the local HTML coverage command in `Makefile` from `-p phpdbg` to `-p php`

## Testing

- [x] `make tests`
- [ ] `make coverage` locally

`make coverage` currently fails in this environment because PHP is running without Xdebug, PCOV, or PHPDBG, which Nette Tester requires for coverage collection when using `-p php`.